### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://nishaisheetspp.visualstudio.com/f5c7f457-f33d-44e6-acfe-7088a8869df1/f6a5c9d6-8374-4d54-a4c8-e65bfeffc99f/_apis/work/boardbadge/bf60f2bc-aacb-40ff-a39f-c0db1f551f99)](https://nishaisheetspp.visualstudio.com/f5c7f457-f33d-44e6-acfe-7088a8869df1/_boards/board/t/f6a5c9d6-8374-4d54-a4c8-e65bfeffc99f/Microsoft.RequirementCategory)
 install pacgakes from the requirements.txt file:
 
 python -m pip freeze > requirement.txt   


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://nishaisheetspp.visualstudio.com/f5c7f457-f33d-44e6-acfe-7088a8869df1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.